### PR TITLE
Negative match patch

### DIFF
--- a/restricted-ssh-commands
+++ b/restricted-ssh-commands
@@ -47,8 +47,8 @@ fi
 
 num_rules=0
 while IFS='' read -r line; do
-    # Skip empty lines and lines starting with hashes
-    if ! [[ "$line" =~ ^[[:space:]]*(#|$) ]]; then
+    # Skip empty lines and lines starting with hashes or bangs
+    if ! [[ "$line" =~ ^[[:space:]]*(#|!|$) ]]; then
         if [[ "${SSH_ORIGINAL_COMMAND-}" =~ $line ]]; then
             if test -n "${RSC_VERBOSE-}"; then
                 log "${0##*/}: \"${SSH_ORIGINAL_COMMAND-}\" matches \"$line\""
@@ -62,7 +62,27 @@ while IFS='' read -r line; do
             fi
         fi
     elif test -n "${RSC_VERBOSE-}"; then
-        log "${0##*/}: Skipping commented/empty configuration line: \"$line\""
+        log "${0##*/}: Skipping commented/empty/negative configuration line on first pass: \"$line\""
+    fi
+done < "$config_file"
+
+while IFS='' read -r line; do
+    # Only look at lines starting with bang
+    if [[ "$line" =~ ^! ]]; then
+        line=${line:1};
+        if [[ "${SSH_ORIGINAL_COMMAND-}" =~ $line ]]; then
+            if test -n "${RSC_VERBOSE-}"; then
+                log "${0##*/}: \"${SSH_ORIGINAL_COMMAND-}\" matches negative \"!$line\""
+            fi
+            negate=1
+            break
+        else
+            if test -n "${RSC_VERBOSE-}"; then
+                log "${0##*/}: Regular expression does not match: negative !\"$line\""
+            fi
+        fi
+    elif test -n "${RSC_VERBOSE-}"; then
+        log "${0##*/}: Skipping commented/empty/regex configuration line on second pass: \"$line\""
     fi
 done < "$config_file"
 
@@ -81,4 +101,9 @@ if test -z "${found-}"; then
     fi
 fi
 
-exec ${SHELL:-/bin/sh} -c "${SSH_ORIGINAL_COMMAND-}"
+if test -z "${negate-}"; then
+    exec ${SHELL:-/bin/sh} -c "${SSH_ORIGINAL_COMMAND-}"
+else
+    log "Rejecting command \"${SSH_ORIGINAL_COMMAND-}\". It matches a negative rule in $config_file."
+    exit 124
+fi

--- a/restricted-ssh-commands.pod
+++ b/restricted-ssh-commands.pod
@@ -36,6 +36,10 @@ To enable debug output, set the RSC_VERBOSE environment variable to a nonzero
 value, e.g. by adding it to authorized_keys:
 
     command="RSC_VERBOSE=1 /usr/lib/restricted-ssh-commands"
+    
+It is also possible to use the ForceCommand parameter in /etc/ssh/sshd_config:
+
+    ForceCommand /usr/lib/restricted-ssh-commands
 
 =head1 EXIT STATUS
 
@@ -49,7 +53,8 @@ exit codes.
 =item C<124>
 
 A configuration file was found and contains at least one regular expression, but
-the requested command does not match any of those regular expressions.
+the requested command does not match any of those regular expressions, or also
+matches one or more negated expression (indicated with a leading !).
 
 =item C<125>
 
@@ -69,6 +74,7 @@ three regular expressions:
     ^scp -p( -d)? -t( --)? /srv/reprepro/incoming(/[-A-Za-z0-9+~_.]*[-A-Za-z0-9+~_])?$
     ^chmod 0644( /srv/reprepro/incoming/[-A-Za-z0-9+~_.]*[-A-Za-z0-9+~_])+$
     ^reprepro ( -V)? -b /srv/reprepro processincoming foobar$
+    !(badname1|badname2)
 
 =head1 SECURITY NOTES
 
@@ -90,8 +96,10 @@ only use positive bracked expressions (like [a-z]).
 
 The configuration files are placed in F</etc/restricted-ssh-commands/>. Each
 line in the configuration file represents one POSIX extended regular expression
-(ERE). Lines starting with # are considered as comments and are ignored. Empty
-lines (containing only whitespaces) are ignored, too.
+(ERE). Line starting with ! are negative matching lines, the ! is stripped and
+if the remaining ERE matches the command, it is rejected. Lines starting with #
+are considered as comments and are ignored. Empty lines (containing only
+whitespaces) are ignored, too.
 
 =head1 SEE ALSO
 

--- a/test-restricted-ssh-commands
+++ b/test-restricted-ssh-commands
@@ -77,6 +77,12 @@ test_two_rules_config() {
     failure "true" "bar" "restricted-ssh-commands: Rejecting command \"true\". It does not match any of the 2 allow rules in ${SHUNIT_TMPDIR}/etc/restricted-ssh-commands/bar."
 }
 
+test_negation_rule() {
+    add_rule "bar" '^true$'
+    add_rule "bar" '!ru'
+    failure "true" "bar" "restricted-ssh-commands: Rejecting command \"true\". It matches a negative rule in ${SHUNIT_TMPDIR}/etc/restricted-ssh-commands/bar."
+}
+
 test_matching_rule() {
     add_rule "foo" '^true$'
     success "true" "foo" ""


### PR DESCRIPTION
This patch adds a simple negative rule option to the existing config file.  I think this addresses open issue #3.
I added a test case, but am not setup to use shunit2, so I did not run the test case, sorry about that.